### PR TITLE
update features_tcga to include TIL Maps features

### DIFF
--- a/R/features_tcga.R
+++ b/R/features_tcga.R
@@ -49,7 +49,7 @@ features_tcga <- function(){
         .data$method_tag
       )
     ) %>%
-    dplyr::filter(!is.na(.data$method_tag)) %>%
+    #dplyr::filter(!is.na(.data$method_tag)) %>% #commenting it out because this filter removes all TIL Maps features and age, weight, height
     dplyr::add_row(
       "name" = "Tumor_fraction",
       "display" = "Tumor Fraction",


### PR DESCRIPTION
@andrewelamb, currently no feature associated with TIL Maps is returned from our database (https://github.com/CRI-iAtlas/iatlas-app/issues/246). The original manifest file does not have TIL maps features. This is due to the fact that features_tcga.R excludes features with no method_tag. In this PR, I removed this filter, but I haven't updated the manifest file or merged this code change because I wanted to check with you the best course of action. 
Is it ok to have a feature with no method tag or is there a constraint that a feature MUST have one? 